### PR TITLE
Fix wrong argument in CLI tools code signing

### DIFF
--- a/src/docs/deployment/ios.md
+++ b/src/docs/deployment/ios.md
@@ -316,7 +316,7 @@ Fetch the code signing files from App Store Connect:
 
 ```bash
 app-store-connect fetch-signing-files YOUR.APP.BUNDLE_ID \
-    --platform IOS_APP_STORE \
+    --type IOS_APP_STORE \
     --certificate-key=@file:/path/to/cert_key \
     --create
 ```


### PR DESCRIPTION
`app-store-connect fetch` argument should be  `--type` instead of `--platform` according to the CLI tools [docs](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/app-store-connect/fetch-signing-files.md#--typeios_app_adhoc--ios_app_development--ios_app_inhouse--ios_app_store--mac_app_development--mac_app_direct--mac_app_store--mac_catalyst_app_development--mac_catalyst_app_direct--mac_catalyst_app_store--tvos_app_adhoc--tvos_app_development--tvos_app_inhouse--tvos_app_store)

(It's faster to merge PR than create an issue)

**IMPORTANT:** Due to work on the flutter.dev infrastructure, this repo is **not accepting pull requests**.

Instead of creating a PR, please file an issue (https://github.com/flutter/website/issues/new/choose) about the needed change.

We expect to start accepting PRs again August 23.
